### PR TITLE
Set SyslogIdentifier to something meaningful

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -8,7 +8,7 @@ pkgbase = autoupdate
 	license = GPL
 	source = autoupdate.service
 	source = autoupdate.timer
-	md5sums = 315777ea88d1ca6be7a934844a48c399
+	md5sums = 3d9f8d9a766ed6d6b997f61ced458127
 	md5sums = 129db06fab0fd9478ef3a4cf6a5baa96
 
 pkgname = autoupdate

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -10,7 +10,7 @@ license=('GPL')
 install=autoupdate.install
 source=(autoupdate.service
         autoupdate.timer)
-md5sums=('315777ea88d1ca6be7a934844a48c399'
+md5sums=('3d9f8d9a766ed6d6b997f61ced458127'
          '129db06fab0fd9478ef3a4cf6a5baa96')
 
 package() {

--- a/autoupdate.service
+++ b/autoupdate.service
@@ -4,6 +4,7 @@ After=network-online.target
 
 [Service]
 Type=simple
+SyslogIdentifier=autoupdate
 ExecStart=/usr/bin/nice -n 19 /usr/bin/pacman -Syuwq --noconfirm
 TimeoutStopSec=300
 KillMode=process


### PR DESCRIPTION
Currently, journalctl prefixes executions of autoupdate as 'nice' because it defaults to using the process name of the executed process. This changes the prefix to 'autoupdate'.